### PR TITLE
Update fb model to capture names vs handles

### DIFF
--- a/package/top_fibers_pkg/data_model.py
+++ b/package/top_fibers_pkg/data_model.py
@@ -318,6 +318,13 @@ class FbIgPost(PostBase):
         Return the account handle of the user (str)
         """
         return self.get_value(["account", "handle"])
+    
+    def get_account_name(self):
+        """
+        Some accounts do not have "handles" and instead have "names." For example,
+        if "accountType" is facebook_page or facebook_group.
+        """
+        return self.get_value(["account", "name"])
 
     def get_link_to_author(self):
         """

--- a/package/top_fibers_pkg/utils.py
+++ b/package/top_fibers_pkg/utils.py
@@ -134,7 +134,7 @@ def parse_cl_args_fib(script_purpose="", logger=None):
         "-m",
         "--month-calculated",
         metavar="Month calculated",
-        help="The month for which you'd like to calculate FIB indices (YYYY-MM)",
+        help="The month for which you'd like to calculate FIB indices (YYYY_MM)",
         required=True,
     )
     parser.add_argument(

--- a/package/top_fibers_pkg/utils.py
+++ b/package/top_fibers_pkg/utils.py
@@ -189,11 +189,15 @@ def parse_cl_args_ct_dl(script_purpose="", logger=None):
         help=msg,
         required=True,
     )
+    msg = (
+        "Directory where you'd like to save the output data. E.g.: "
+        "/home/data/apps/topfibers/repo/data/raw/facebook"
+    )
     parser.add_argument(
         "-o",
         "--out-dir",
         metavar="Output dir",
-        help="Directory where you'd like to save the output data",
+        help=msg,
         required=True,
     )
     parser.add_argument(

--- a/scripts/data_processing/calc_crowdtangle_fib_indices.py
+++ b/scripts/data_processing/calc_crowdtangle_fib_indices.py
@@ -123,6 +123,11 @@ def extract_data_from_files(data_files, earliest_date_tstamp):
                         continue
                     user_id = post_obj.get_user_ID()
                     username = post_obj.get_user_handle()
+
+                    # This handles certain types of accounts like groups and pages that
+                    # do not have "handles" (or don't provide one) but instead have "names"
+                    if username in [None, ""]:
+                        username = post_obj.get_account_name()
                     reshare_count = post_obj.get_reshare_count()
                     if reshare_count is None:
                         reshare_count = 0


### PR DESCRIPTION
`scripts/data_processing/calc_crowdtangle_fib_indices.py` was returning many usernames with values of `None` and `""`. This PR handles this issue.

More background: Certain types of Facebook accounts do not have usernames but instead have "names." Furthermore, some accounts enter a blank username (i.e., `""`) and instead fill out the "name" field. I added a method in the FB post model and updated the script to handle this case. I also cleaned up some cl arg messages.